### PR TITLE
Add notification to user that snapshotter is ready and listening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0 // indirect
+	github.com/urfave/cli v1.20.0
 	go.etcd.io/bbolt v1.3.2 // indirect
 	google.golang.org/grpc v1.18.0
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
@@ -14,15 +15,16 @@ import (
 	lvms "github.com/ganeshmaharaj/lvm-snapshotter/lvmsnapshotter"
 )
 
-func main() {
-	// Provide a unix address to listen to, this will be the `address`
-	// in the `proxy_plugin` configuration.
-	// The root will be used to store the snapshots.
-	if len(os.Args) < 4 {
-		fmt.Printf("invalid args: usage: %s <unix addr> <vgname> <lvpoolname>\n", os.Args[0])
-		os.Exit(1)
-	}
+var usage = fmt.Sprint(`an image layering tool using the containerd shapshots
+	 API and the thin logical volume device mapper of LVM.
 
+	 To run lvm-snapshotter a path to the unix socket address, volume group name,
+	 and logical volume pool name are required:
+
+	 $ lvm-snapshotter --addr /path/to/socket --vgname volumegroup --lvpoolname poolname
+`)
+
+func prepareSnapshotter(addr, vgname, lvpoolname string) error {
 	// Create a gRPC server
 	rpc := grpc.NewServer()
 
@@ -30,10 +32,9 @@ func main() {
 	// snapshotter and a root directory. Your custom snapshotter will be
 	// much more useful than using a snapshotter which is already included.
 	// https://godoc.org/github.com/containerd/containerd/snapshots#Snapshotter
-	sn, err := lvms.NewSnapshotter(os.Args[2], os.Args[3])
+	sn, err := lvms.NewSnapshotter(vgname, lvpoolname)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	defer sn.Close()
 
@@ -55,13 +56,53 @@ func main() {
 	}()
 
 	// Listen and serve
-	l, err := net.Listen("unix", os.Args[1])
+	l, err := net.Listen("unix", addr)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	if err := rpc.Serve(l); err != nil {
-		fmt.Printf("error: %v\n", err)
+		return err
+	}
+	return nil
+}
+
+func createApp() error {
+	var addr string
+	var vgname string
+	var lvpoolname string
+
+	app := cli.NewApp()
+	app.Name = "lvmsnapshotter"
+	app.Usage = usage
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "addr",
+			Usage: "the socket the snapshotter will listen on, it is the 'address' in the containerd 'proxy plugin' configuration.",
+			Destination: &addr,
+		},
+		cli.StringFlag{
+			Name:  "vgname",
+			Usage: "name of created volume group",
+			Destination: &vgname,
+		},
+		cli.StringFlag{
+			Name:  "lvpoolname",
+			Usage: "name of logical volume pool",
+			Destination: &lvpoolname,
+		},
+	}
+	app.Action = func(ctx *cli.Context) error {
+		if ctx.NumFlags() != 3 {
+			return fmt.Errorf("incorrect usage, view help for correct argument usage")
+		}
+		return prepareSnapshotter(addr, vgname, lvpoolname)
+	}
+	return app.Run(os.Args)
+}
+
+func main() {
+	if err := createApp(); err != nil {
+		fmt.Println("error:", err)
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func prepareSnapshotter(addr, vgname, lvpoolname string) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("Ready and listening on socket %s...", addr)
 	if err := rpc.Serve(l); err != nil {
 		return err
 	}

--- a/tests/test_snapshotter.sh
+++ b/tests/test_snapshotter.sh
@@ -41,7 +41,7 @@ function create_lvm_stuff()
 
 function start_snapshotter()
 {
-  cmd="$(pwd)/lvm-snapshotter /var/run/lvmsnapshotter.sock vgthin lvthinpool"
+  cmd="$(pwd)/lvm-snapshotter --addr /var/run/lvmsnapshotter.sock --vgname vgthin --lvpoolname lvthinpool"
   nohup sudo $cmd 2>&1 > /tmp/lvmsnapshotter.log &
 }
 


### PR DESCRIPTION
When the snapshotter is listening, and ready to be used the most recent print is: "Running command mount with args: [-rw /dev/vgthin/contd-metadata-holder /mnt/contd-lvm-snapshotter-db-holder/]". To a user that may look like the program is stuck attempting to mount. Add a print statement to let them know the snapshotter is listening on the socket and ready to be served. 